### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/fraim/security/code-scanning/5](https://github.com/ScottBrenner/fraim/security/code-scanning/5)

To resolve the issue, a `permissions` block should be added at the top level of the workflow, immediately after the workflow `name` definition. This block will apply least privilege settings to all jobs unless overridden at the job level. Since no steps in any job require write access to repository contents or other resources (such as issues, deployments, checks, or packages), the minimal safe configuration is:

```yaml
permissions:
  contents: read
```

This grants read-only access to repository contents—sufficient for actions such as checking out code and reading files, but prevents accidental or malicious modifications via the GitHub Actions token. No jobs require an exception to this default restriction. Insert this block directly beneath the `name:` (line 1).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
